### PR TITLE
feat(profile): CVE/FVE 신규 등재분을 소개·포트폴리오에 반영

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -17,7 +17,14 @@ import {
 } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { CertificationsSection } from "@/components/skills/certifications-section";
-import { CVE_COUNT, CVE_GROUPS, CVE_ITEMS } from "@/data/cves";
+import {
+  CVE_BREAKDOWN,
+  CVE_COUNT,
+  CVE_GROUPS,
+  CVE_ITEMS,
+  CVE_ONLY_COUNT,
+  FVE_COUNT,
+} from "@/data/cves";
 import type {
   CertCompanyGroup,
   ExperienceItem,
@@ -46,7 +53,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 const PROFILE = {
   name: "홍승표 (ph4nt0m)",
   headline:
-    `Offensive Security Researcher | Web/App · OT/ICS Pentesting | CVE ${CVE_COUNT} | AI Security Automation`,
+    `Offensive Security Researcher | Web/App · OT/ICS · LLM Pentesting | CVE ${CVE_ONLY_COUNT} · FVE ${FVE_COUNT} | AI Security Automation`,
   location: "Seoul, South Korea",
   website: "mailto:newbiepwner@kakao.com",
   connections: String(CVE_COUNT),
@@ -58,7 +65,7 @@ const PROFILE = {
   },
 } as const;
 
-const ABOUT_TEXT = `Offensive Security Researcher. CVE ${CVE_COUNT}건(Kernel 16 + IoT 5) 보유. 금융권 Web/App과 OT/ICS 점검, BoB 8기 커널 퍼징, 그리고 AI 기반 점검 자동화에 집중하고 있습니다. 상세 레지스트리는 /cves에서 관리합니다.`;
+const ABOUT_TEXT = `Offensive Security Researcher. CVE ${CVE_ONLY_COUNT}건(${CVE_BREAKDOWN})과 FVE ${FVE_COUNT}건 보유. 금융권 Web/App과 OT/ICS 점검, BoB 8기 커널 퍼징, 최근에는 llama.cpp 등 LLM 추론 엔진 취약점 연구와 AI 기반 점검 자동화에 집중하고 있습니다. 상세 레지스트리는 /cves에서 관리합니다.`;
 
 const EXPERIENCE: ExperienceItem[] = [
   {
@@ -171,6 +178,15 @@ const EDUCATION: EducationRow[] = [
 ];
 
 const PROJECTS: ProjectItem[] = [
+  {
+    title: "LLM 추론 엔진 취약점 연구 (llama.cpp)",
+    meta: "취약점 분석 (2026)",
+    bullets: [
+      "llama.cpp 서버 대상 취약점 분석 → CVE 3건 도출 (CVE-2026-52130 / 52131 / 52132)",
+      "json-schema-to-grammar 무제어 재귀 DoS(CWE-674, CVSS 7.5) — /completions 경로만 영향, jinja 경유 /v1/chat/completions는 비해당까지 경로별 검증",
+      "GGUF 파서 도달 가능한 어서션(CWE-617)·/rerank 음수 top_n 정수 오버플로 DoS(CWE-190) 식별",
+    ],
+  },
   {
     title: "AI Orchestration Framework for Security",
     meta: "개인 연구 (2024 — Present)",

--- a/src/app/[locale]/portfolio/page.tsx
+++ b/src/app/[locale]/portfolio/page.tsx
@@ -21,7 +21,13 @@ import {
   FEATURED_PROJECTS,
   PORTFOLIO_PROJECT_COUNT,
 } from "@/data/portfolio";
-import { CVE_COUNT, CVE_ITEMS } from "@/data/cves";
+import {
+  CVE_BREAKDOWN,
+  CVE_COUNT,
+  CVE_ITEMS,
+  CVE_ONLY_COUNT,
+  FVE_COUNT,
+} from "@/data/cves";
 import type { ExperienceItem } from "@/types/profile";
 
 interface Props {
@@ -42,7 +48,7 @@ const PROFILE = {
   name: "홍승표 (ph4nt0m)",
   headline:
     "Offensive Security Researcher · Web/App · OT/ICS Pentesting · 보안 컨설팅",
-  summary: `금융권 Web/App 모의해킹부터 OT/ICS(IEC 62443)·IoT·의료기기(FDA) 보안, 사이버 공방 훈련 개발까지 ${PORTFOLIO_PROJECT_COUNT}건 이상의 프로젝트를 수행했습니다. LS ELECTRIC 자동화기기 Achilles Communication Certificate Level 2 인증 취득, NATO CCDCOE Locked Shields 2025 DFIR CTF 1위, Linux Kernel CVE 16건·IoT CVE 5건·FVE 3건 보유.`,
+  summary: `금융권 Web/App 모의해킹부터 OT/ICS(IEC 62443)·IoT·의료기기(FDA) 보안, 사이버 공방 훈련 개발까지 ${PORTFOLIO_PROJECT_COUNT}건 이상의 프로젝트를 수행했습니다. LS ELECTRIC 자동화기기 Achilles Communication Certificate Level 2 인증 취득, NATO CCDCOE Locked Shields 2025 DFIR CTF 1위, CVE ${CVE_ONLY_COUNT}건(${CVE_BREAKDOWN})·FVE ${FVE_COUNT}건 보유.`,
   location: "Seoul, South Korea",
   email: "newbiepwner@kakao.com",
   avatar: "/images/avatar.jpg",
@@ -52,6 +58,7 @@ const CORE_COMPETENCIES: string[] = [
   "금융·공공 전자금융기반시설 Web/App 모의해킹 — 저축은행·캐피탈·증권·보험·제조 등 12개 사이트 수행 (A3 Security)",
   "OT/ICS 보안 — IEC 62443-4-2 기반 Threat Modeling·모의해킹, LS ELECTRIC 자동화기기 Achilles Communication Certificate Level 2 인증 취득",
   "IoT 취약점 분석·보안 도구 개발 — 스마트빌딩 IoT 탐지 기술, IoT/CCTV 침해사고 조사 도구, Linux Kernel File System Fuzzer로 CVE 16건 도출",
+  "LLM·AI 인프라 보안 — llama.cpp 추론 엔진 취약점 분석으로 CVE 3건 도출(DoS·도달 가능 어서션·정수 오버플로), MCP 기반 점검 자동화 연구",
   "의료기기 보안 — FDA eSTAR 컨설팅 및 Web/App·의료기기 모의해킹, 보안인증 취득 지원",
   "사이버 공방 훈련 개발·운영 — 한국전력 ELECCON, NATO CCDCOE Locked Shields 2025 DFIR CTF 1위, APEX CTF 2025 문제 개발",
 ];

--- a/src/data/cves.ts
+++ b/src/data/cves.ts
@@ -726,6 +726,25 @@ export const CVE_ITEMS: CveEntry[] = CVE_SOURCE_ITEMS.map(normalizeCveEntry);
 
 export const CVE_COUNT = CVE_ITEMS.length;
 
+/** CVE(공식 채번)만. FVE는 제외 — 이력서·소개 문구에서 둘을 섞어 세면 안 된다. */
+export const CVE_ONLY_COUNT = CVE_ITEMS.filter((item) => item.kind === "cve").length;
+
+/** FVE(Findthegap 플랫폼 채번)만. */
+export const FVE_COUNT = CVE_ITEMS.filter((item) => item.kind === "fve").length;
+
+/**
+ * 소개·포트폴리오 본문에 넣을 CVE 내역 문자열.
+ * 예: "Kernel 16 + IoT 5 + LLM 3"
+ * 하드코딩하면 CVE 추가할 때마다 썩는다 — 데이터에서 파생시킨다.
+ */
+export const CVE_BREAKDOWN = CVE_GROUP_DEFINITIONS.map((group) => ({
+  label: group.shortLabel,
+  count: CVE_ITEMS.filter((item) => item.groupKey === group.key && item.kind === "cve").length,
+}))
+  .filter((group) => group.count > 0)
+  .map((group) => `${group.label} ${group.count}`)
+  .join(" + ");
+
 export const CVE_GROUPS: CveGroupSummary[] = CVE_GROUP_DEFINITIONS.map((group) => ({
   key: group.key,
   label: group.label,

--- a/src/data/portfolio.ts
+++ b/src/data/portfolio.ts
@@ -16,7 +16,8 @@ export type PortfolioCategoryKey =
   | "iot"
   | "medical"
   | "cyber-range"
-  | "consulting";
+  | "consulting"
+  | "vuln-research";
 
 export interface PortfolioCategory {
   key: PortfolioCategoryKey;
@@ -55,6 +56,7 @@ export const PORTFOLIO_CATEGORIES: PortfolioCategory[] = [
   { key: "medical", label: "의료기기 보안 (FDA/eSTAR)" },
   { key: "cyber-range", label: "사이버훈련장·CTF 개발" },
   { key: "consulting", label: "보안 컨설팅·인증" },
+  { key: "vuln-research", label: "취약점 연구 (CVE/FVE)" },
 ];
 
 export const PORTFOLIO_PROJECTS: PortfolioProject[] = [
@@ -100,6 +102,47 @@ export const PORTFOLIO_PROJECTS: PortfolioProject[] = [
       "Locked Shields 2026 — 한국-헝가리 연합 Special System 블루팀, 종합 9위",
     ],
     stack: ["DFIR", "Volatility", "Wireshark", "Sysmon", "YARA"],
+  },
+  {
+    title: "llama.cpp LLM 추론 엔진 취약점 연구 (CVE 3건)",
+    client: "ggml-org/llama.cpp (오픈소스)",
+    period: "2026.07 — 2026.08",
+    category: "vuln-research",
+    role: "취약점 분석·리포팅 주담당",
+    contribution: 100,
+    featured: true,
+    background:
+      "LLM 추론 엔진이 사내·제품 인프라에 빠르게 편입되는 반면, 서버 모드로 노출되는 공격 표면은 검증이 얕았다. llama.cpp 서버의 외부 입력 처리 경로(문법 변환·모델 파서·랭킹 API)를 대상으로 원격 비인증 공격 가능성을 검증했다.",
+    actions: [
+      "json-schema-to-grammar의 SchemaConverter::visit·_generate_union_rule 무제어 재귀 분석 — 재귀 깊이 7000 이상에서 기본 8MB 스레드 스택 고갈로 DoS 재현 (CVE-2026-52130, CWE-674, CVSS 7.5)",
+      "영향 경로 한정 검증 — POST /completions만 해당하며 /v1/chat/completions는 jinja 엔진 경유로 비해당임을 확인해 오탐 없는 영향 범위 산정",
+      "gguf_reader::read 도달 가능한 어서션으로 악성 GGUF 모델 로드 시 프로세스 abort 유도 (CVE-2026-52131, CWE-617)",
+      "/rerank 엔드포인트 음수 top_n 정수 오버플로 기반 DoS 식별 및 PoC 작성 (CVE-2026-52132, CWE-190)",
+    ],
+    results: [
+      "llama.cpp 대상 CVE 3건 채번 — CVE-2026-52130 / 52131 / 52132",
+      "원격 비인증 DoS 2건(CVSS 7.5) 포함, 취약 경로·비취약 경로를 구분한 재현 절차 업스트림 제공",
+    ],
+    stack: ["C/C++", "llama.cpp", "GGUF", "Fuzzing", "CVSS 3.1", "PoC"],
+  },
+  {
+    title: "데이터 플랫폼 무인증 IDOR 취약점 신고 (FVE)",
+    client: "비공개 (Findthegap 버그바운티)",
+    period: "2026.08",
+    category: "vuln-research",
+    role: "취약점 분석·신고",
+    contribution: 100,
+    featured: false,
+    background:
+      "버그바운티 플랫폼을 통해 데이터 API의 인증·접근통제를 점검했다. 신고 정책에 따라 제품·벤더·엔드포인트·파라미터·재현 절차는 공개하지 않는다.",
+    actions: [
+      "데이터 조회 API의 인증 부재 및 객체 참조 검증 미흡 확인 (CWE-306 / CWE-200 / CWE-284)",
+      "개인정보 마스킹 우회 가능성 검증 후 플랫폼 정책에 따라 신고",
+    ],
+    results: [
+      "FVE-2026-8617-75112 채번 — 무인증 IDOR 및 마스킹 우회 (상세 마스킹)",
+    ],
+    stack: ["Web", "API Security", "IDOR", "Burp Suite"],
   },
   {
     title: "IoT/CCTV 침해사고 조사 도구 개발",


### PR DESCRIPTION
## 배경

직전 PR(#8)로 llama.cpp CVE 3건 + FVE 1건이 레지스트리(`src/data/cves.ts`)에 등재됐으나, 소개(`/about`)·포트폴리오(`/portfolio`) 문구에는 반영되지 않아 실제 보유 내역과 어긋나 있었다.

## 수치 오류 수정

| 위치 | 기존 | 문제 | 수정 |
|---|---|---|---|
| about 헤드라인 | `CVE 28` | `CVE_COUNT`는 CVE+FVE 합계 → **FVE 4건이 CVE로 집계** | `CVE 24 · FVE 4` |
| about 본문 | `CVE 28건(Kernel 16 + IoT 5)` | 괄호 안 수동 문구, LLM 3건 누락, 합계 불일치 | `CVE 24건(Kernel 16 + IoT 5 + LLM 3)과 FVE 4건` |
| portfolio 요약 | `Kernel 16·IoT 5·FVE 3` | 전부 수동, LLM 누락, FVE 수 낡음 | 데이터 파생 |

`cves.ts`에 파생 상수 `CVE_ONLY_COUNT`(24) / `FVE_COUNT`(4) / `CVE_BREAKDOWN`(`"Kernel 16 + IoT 5 + LLM 3"`)을 추가해, 이후 CVE 추가 시 문구가 자동으로 따라오게 했다. 배지 카운트(`connections`)는 총합이 맞아 `CVE_COUNT` 유지.

## 내용 반영

- **about** — `LLM 추론 엔진 취약점 연구 (llama.cpp)` 프로젝트 추가. CVE 3건과 경로별 영향 범위(`/completions`만 해당, `/v1/chat/completions`는 jinja 경유로 비해당) 명시.
- **portfolio** — `vuln-research` 카테고리 신설 + 프로젝트 2건
  - llama.cpp 취약점 연구 (featured, STAR 상세)
  - 데이터 플랫폼 무인증 IDOR FVE — **신고 정책에 따라 제품·벤더·엔드포인트·파라미터·재현 절차 마스킹 유지**
- 핵심역량에 LLM·AI 인프라 보안 항목 추가

프로젝트 24 → 26건.

## 검증

- `npx tsc --noEmit` 통과
- `npm run build` 통과 (전 로케일 SSG)

## 확인 필요

1. llama.cpp 기간을 `2026.07 — 2026.08`로 기재 — CVE 공개일에서 역산한 **추정치**. 실제 분석 시작 시점 확인 필요.
2. FVE 프로젝트 발주처를 `비공개 (Findthegap 버그바운티)`로 기재 — 플랫폼명 노출이 신고 정책상 문제되면 `비공개`로만 축약 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)