### PR TITLE
feat(cv): 이력서·경력기술서 10종에 LLM CVE 3건·FVE 4건 반영

### DIFF
--- a/scripts/cv/Hong_Seungpyo_CV.yaml
+++ b/scripts/cv/Hong_Seungpyo_CV.yaml
@@ -13,7 +13,7 @@ cv:
 
   sections:
     summary:
-      - "NATO CCDCOE Locked Shields 2025 DFIR CTF #1 · 21 CVEs (OS Kernel 16 + IoT 5). Offensive Security Researcher with 6 years across financial Web/App pentesting and OT/ICS security. Built an AI Orchestration Framework (IDA · Burp Suite · Frida · CodeQL via MCP + A2A) that auto-identifies Low–Medium vulnerabilities on live targets."
+      - "NATO CCDCOE Locked Shields 2025 DFIR CTF #1 · 24 CVEs (OS Kernel 16 + IoT 5 + LLM 3). Offensive Security Researcher with 6 years across financial Web/App pentesting and OT/ICS security. Built an AI Orchestration Framework (IDA · Burp Suite · Frida · CodeQL via MCP + A2A) that auto-identifies Low–Medium vulnerabilities on live targets."
 
     experience:
       - company: CoreSecurity
@@ -61,6 +61,12 @@ cv:
 
       - label: "IoT CVEs (5) — Independent Research"
         details: "Embedded/IoT device vulnerability analysis. CVE-2024-33788 (CVSS 8.0 HIGH), CVE-2024-33789 (CVSS 9.8 CRITICAL), CVE-2024-33791 (CVSS 4.6 MEDIUM), CVE-2024-33792 (CVSS 9.8 CRITICAL), CVE-2024-33793 (CVSS 5.3 MEDIUM)"
+
+      - label: "LLM CVEs (3) — Independent Research"
+        details: "LLM inference engine (llama.cpp) vulnerability analysis. CVE-2026-52130 (CVSS 7.5 HIGH, CWE-674 uncontrolled recursion DoS in json-schema-to-grammar), CVE-2026-52132 (CVSS 7.5 HIGH, CWE-190 integer overflow DoS via /rerank negative top_n), CVE-2026-52131 (CVSS 5.5 MEDIUM, CWE-617 reachable assertion in gguf_reader::read on malicious model load)"
+
+      - label: "Bug Bounty — 4 FVEs (FindTheGap)"
+        details: "Access control and authentication flaws reported through a private bug bounty program: missing authentication enabling account takeover, unauthorized identity-verification data exposure, and unauthenticated API access leaking personal data (CVSS up to 9.8 CRITICAL; CWE-284, CWE-306, CWE-200). Target and technical details withheld under disclosure policy."
 
     projects:
       - name: AI Orchestration Framework for Security

--- a/scripts/cv/Hong_Seungpyo_CV_coupang_kor.yaml
+++ b/scripts/cv/Hong_Seungpyo_CV_coupang_kor.yaml
@@ -15,7 +15,7 @@ cv:
 
   sections:
     요약:
-      - "금융·공공 Web/App/API 모의해킹부터 레드팀 훈련까지 6년 경력의 Offensive Security Researcher. 국내 대형 유통사 프로덕션에서 회원번호 하나로 임의 계정을 탈취하는 경로(CVSS 9.8)를 포함한 버그바운티를 제보했고, NATO Locked Shields·한국전력 ELECCON에서 MITRE ATT&CK 기반 공격 시나리오를 설계했습니다. Burp Suite·Metasploit·Nmap 기반 침투 테스트와 Python 자동화 도구 개발에 강점. Linux Kernel CVE 16건 + IoT CVE 5건, Locked Shields 2025 DFIR CTF 1위."
+      - "금융·공공 Web/App/API 모의해킹부터 레드팀 훈련까지 6년 경력의 Offensive Security Researcher. 국내 대형 유통사 프로덕션에서 회원번호 하나로 임의 계정을 탈취하는 경로(CVSS 9.8)를 포함한 버그바운티를 제보했고, NATO Locked Shields·한국전력 ELECCON에서 MITRE ATT&CK 기반 공격 시나리오를 설계했습니다. Burp Suite·Metasploit·Nmap 기반 침투 테스트와 Python 자동화 도구 개발에 강점. Linux Kernel CVE 16건 + IoT CVE 5건 + LLM 추론 엔진 CVE 3건, Locked Shields 2025 DFIR CTF 1위."
 
     경력:
       - company: 코어시큐리티 (CoreSecurity)
@@ -70,8 +70,11 @@ cv:
       - label: "IoT CVE 5건 — 개인 연구"
         details: "임베디드/IoT 장비 취약점 분석. CVE-2024-33788 (CVSS 8.0 HIGH), CVE-2024-33789 (CVSS 9.8 CRITICAL), CVE-2024-33791 (CVSS 4.6 MEDIUM), CVE-2024-33792 (CVSS 9.8 CRITICAL), CVE-2024-33793 (CVSS 5.3 MEDIUM)"
 
-      - label: "버그바운티 3건 — 이커머스 프로덕션 웹/API 접근통제 결함"
-        details: "국내 대형 유통사 프로덕션 서비스 취약점 신고. 인증 없이 전 회원 비밀번호 변경으로 임의 계정 탈취(CVSS 9.8 Critical, Broken Access Control), 본인인증 엔드포인트 인가 미적용으로 개인정보(CI·전화번호·실명) 노출(CVSS 7.5), 주문 조회 API 순차 열거로 타인 개인정보·결제수단 노출(CVSS 7.5). 모두 소스코드 수준 근본 원인 규명 및 100% 재현."
+      - label: "LLM CVE 3건 — 개인 연구"
+        details: "LLM 추론 엔진(llama.cpp) HTTP 서버 취약점 분석. 원격 비인증 요청만으로 서비스를 마비시키는 경로 2건 포함 — CVE-2026-52130 (CVSS 7.5 HIGH, `/completions` JSON 스키마 무제어 재귀 DoS), CVE-2026-52132 (CVSS 7.5 HIGH, `/rerank` 음수 파라미터 정수 오버플로 DoS), CVE-2026-52131 (CVSS 5.5 MEDIUM, 악성 모델 파일 로드 시 도달 가능한 어서션)"
+
+      - label: "프로덕션 웹/API 버그바운티 4건 — 이커머스·데이터 플랫폼 접근통제 결함"
+        details: "국내 대형 유통사 프로덕션 서비스 취약점 신고 3건 — 인증 없이 전 회원 비밀번호 변경으로 임의 계정 탈취(CVSS 9.8 Critical, Broken Access Control), 본인인증 엔드포인트 인가 미적용으로 개인정보(CI·전화번호·실명) 노출(CVSS 7.5), 주문 조회 API 순차 열거로 타인 개인정보·결제수단 노출(CVSS 7.5). 별도 데이터 플랫폼에서 무인증 IDOR로 실명 명부·연락처 무단 열람(CVSS 7.5) 1건 추가 제보. 모두 소스코드 수준 근본 원인 규명 및 100% 재현."
 
     프로젝트:
       - name: AI Orchestration Framework for Security

--- a/scripts/cv/Hong_Seungpyo_CV_hanwha_kor.yaml
+++ b/scripts/cv/Hong_Seungpyo_CV_hanwha_kor.yaml
@@ -16,7 +16,7 @@ cv:
 
   sections:
     요약:
-      - "산업제어시스템(OT/ICS)·제조 제품 사이버보안 6년 경력. LS ELECTRIC 자동화기기를 위협 모델링부터 IEC 62443-4-2 컴포넌트 인증(Achilles Level 2)까지 지원해 취득에 기여했고, 신약개발 연합학습 플랫폼(K-MELLODDY)에서 NIST SSDF 기반 보안 개발 생명주기(SDL) 정의와 공급망 보안 체계(SBOM/VEX/EoS)를 수립하며 EU CRA·IEC 62443·FDA를 검토했습니다. 결함을 인증 심사를 통과하는 감사 증적으로 옮기는 데 강점. CVE 21건, NATO Locked Shields 2025 DFIR CTF 1위."
+      - "산업제어시스템(OT/ICS)·제조 제품 사이버보안 6년 경력. LS ELECTRIC 자동화기기를 위협 모델링부터 IEC 62443-4-2 컴포넌트 인증(Achilles Level 2)까지 지원해 취득에 기여했고, 신약개발 연합학습 플랫폼(K-MELLODDY)에서 NIST SSDF 기반 보안 개발 생명주기(SDL) 정의와 공급망 보안 체계(SBOM/VEX/EoS)를 수립하며 EU CRA·IEC 62443·FDA를 검토했습니다. 결함을 인증 심사를 통과하는 감사 증적으로 옮기는 데 강점. CVE 24건, NATO Locked Shields 2025 DFIR CTF 1위."
 
     경력:
       - company: 코어시큐리티 (CoreSecurity)
@@ -71,8 +71,11 @@ cv:
       - label: "IoT CVE 5건 — 개인 연구"
         details: "임베디드/IoT 장비 취약점 분석 (UART 펌웨어 접근, binwalk 플래시 추출). CVE-2024-33788 (CVSS 8.0 HIGH), CVE-2024-33789 (CVSS 9.8 CRITICAL), CVE-2024-33791 (CVSS 4.6 MEDIUM), CVE-2024-33792 (CVSS 9.8 CRITICAL), CVE-2024-33793 (CVSS 5.3 MEDIUM)"
 
-      - label: "버그바운티 3건 — 접근통제 결함"
-        details: "프로덕션 웹 서비스 취약점 신고. 인증 없이 전 회원 비밀번호 변경 가능 (CVSS 9.8 Critical, Broken Access Control) 포함 3건 — 소스코드 수준 근본 원인 규명 및 서로 다른 계정으로 100% 재현"
+      - label: "LLM CVE 3건 — 개인 연구"
+        details: "제품에 편입되는 AI 추론 컴포넌트(llama.cpp) 견고성 결함 분석. CVE-2026-52130 (CVSS 7.5 HIGH, 무제어 재귀 DoS), CVE-2026-52132 (CVSS 7.5 HIGH, 정수 오버플로 DoS), CVE-2026-52131 (CVSS 5.5 MEDIUM, 악성 모델 파일 로드 시 도달 가능한 어서션)"
+
+      - label: "버그바운티 FVE 4건 — FindTheGap"
+        details: "프로덕션 웹/API 접근통제·인증 미적용 결함 신고. 계정 탈취 1건 (CVSS 9.8 Critical), 개인정보 노출 3건 (CVSS 7.5 High) — 소스코드 수준 근본 원인 규명 및 서로 다른 계정으로 100% 재현"
 
     프로젝트:
       - name: "ELECCON — 한국전력 사이버 공방 훈련"

--- a/scripts/cv/Hong_Seungpyo_CV_kor.yaml
+++ b/scripts/cv/Hong_Seungpyo_CV_kor.yaml
@@ -13,7 +13,7 @@ cv:
 
   sections:
     요약:
-      - "NATO CCDCOE Locked Shields 2025 DFIR CTF 1위 · CVE 21건 (OS Kernel 16 + IoT 5). 금융권 Web/App 모의해킹 1년, OT/ICS 보안 약 5년 경력의 Offensive Security Researcher. IDA · Burp Suite · Frida · CodeQL을 MCP + A2A로 연결한 AI Orchestration Framework를 구현해 실제 점검 대상에서 Low~Medium 취약점을 자동 식별."
+      - "NATO CCDCOE Locked Shields 2025 DFIR CTF 1위 · CVE 24건 (OS Kernel 16 + IoT 5 + LLM 3). 금융권 Web/App 모의해킹 1년, OT/ICS 보안 약 5년 경력의 Offensive Security Researcher. IDA · Burp Suite · Frida · CodeQL을 MCP + A2A로 연결한 AI Orchestration Framework를 구현해 실제 점검 대상에서 Low~Medium 취약점을 자동 식별."
 
     경력:
       - company: 코어시큐리티 (CoreSecurity)
@@ -68,8 +68,11 @@ cv:
       - label: "IoT CVE 5건 — 개인 연구"
         details: "임베디드/IoT 장비 취약점 분석. CVE-2024-33788 (CVSS 8.0 HIGH), CVE-2024-33789 (CVSS 9.8 CRITICAL), CVE-2024-33791 (CVSS 4.6 MEDIUM), CVE-2024-33792 (CVSS 9.8 CRITICAL), CVE-2024-33793 (CVSS 5.3 MEDIUM)"
 
-      - label: "버그바운티 FVE 3건 — FindTheGap (GS리테일)"
-        details: "GS리테일 / 우리동네GS 웹 서비스 취약점 신고. FVE-2026-8617-74507: 인증 없이 GS ALL 전 회원 비밀번호 변경 가능 (CVSS 9.8 Critical, Broken Access Control + Missing Authentication) · FVE-2026-8617-74513: 본인인증 엔드포인트 인가 미적용 — 주민번호 기반 연계정보(CI)·전화번호·실명 노출 (CVSS 7.5 High) · FVE-2026-8617-74526: 배달 주문 조회 API 인증 미적용 — 순차 열거로 타인 전화번호·이름·결제수단 노출 (CVSS 7.5 High)"
+      - label: "LLM CVE 3건 — 개인 연구"
+        details: "LLM 추론 엔진(llama.cpp) 취약점 분석. CVE-2026-52130 (CVSS 7.5 HIGH, CWE-674 json-schema-to-grammar 무제어 재귀 DoS), CVE-2026-52132 (CVSS 7.5 HIGH, CWE-190 /rerank 음수 top_n 정수 오버플로 DoS), CVE-2026-52131 (CVSS 5.5 MEDIUM, CWE-617 악성 GGUF 모델 로드 시 gguf_reader::read 도달 가능 어서션)"
+
+      - label: "버그바운티 FVE 4건 — FindTheGap"
+        details: "GS리테일 / 우리동네GS 웹 서비스 취약점 신고 3건. FVE-2026-8617-74507: 인증 없이 GS ALL 전 회원 비밀번호 변경 가능 (CVSS 9.8 Critical, Broken Access Control + Missing Authentication) · FVE-2026-8617-74513: 본인인증 엔드포인트 인가 미적용 — 주민번호 기반 연계정보(CI)·전화번호·실명 노출 (CVSS 7.5 High) · FVE-2026-8617-74526: 배달 주문 조회 API 인증 미적용 — 순차 열거로 타인 전화번호·이름·결제수단 노출 (CVSS 7.5 High) · 별도 데이터 플랫폼 신고 1건 — FVE-2026-8617-75112: 데이터 API 인증 미적용 — 실명 명부·연락처 무단 열람 (CVSS 7.5 High)"
 
     프로젝트:
       - name: AI Orchestration Framework for Security

--- a/scripts/cv/Hong_Seungpyo_CV_tuv.yaml
+++ b/scripts/cv/Hong_Seungpyo_CV_tuv.yaml
@@ -16,7 +16,7 @@ cv:
 
   sections:
     summary:
-      - "OT/ICS and embedded security specialist with 6 years across industrial control systems, IoT, and medical devices. Took an LS ELECTRIC PLC line through IEC 62443-4-2 Threat Analysis & Risk Assessment (TARA) to Achilles Level 2 certification, and hold 21 CVEs (16 Linux kernel + 5 IoT). Strong in penetration testing, exploit development, and turning findings into audit evidence that passes certification review — a foundation that transfers directly to RED (EN 18031), Cyber Resilience Act, and NIS2 compliance assessment. NATO CCDCOE Locked Shields 2025 DFIR CTF #1."
+      - "OT/ICS and embedded security specialist with 6 years across industrial control systems, IoT, and medical devices. Took an LS ELECTRIC PLC line through IEC 62443-4-2 Threat Analysis & Risk Assessment (TARA) to Achilles Level 2 certification, and hold 24 CVEs (16 Linux kernel + 5 IoT + 3 LLM). Strong in penetration testing, exploit development, and turning findings into audit evidence that passes certification review — a foundation that transfers directly to RED (EN 18031), Cyber Resilience Act, and NIS2 compliance assessment. NATO CCDCOE Locked Shields 2025 DFIR CTF #1."
 
     experience:
       - company: CoreSecurity
@@ -64,6 +64,12 @@ cv:
 
       - label: "IoT CVEs (5) — Independent Research"
         details: "Embedded/IoT device vulnerability analysis (firmware over UART, binwalk flash extraction). CVE-2024-33788 (CVSS 8.0 HIGH), CVE-2024-33789 (CVSS 9.8 CRITICAL), CVE-2024-33791 (CVSS 4.6 MEDIUM), CVE-2024-33792 (CVSS 9.8 CRITICAL), CVE-2024-33793 (CVSS 5.3 MEDIUM)"
+
+      - label: "LLM CVEs (3) — Independent Research"
+        details: "Robustness and supply-chain review of an AI inference component (llama.cpp) embedded into products, assessed from a standards perspective. CVE-2026-52130 (CVSS 7.5 HIGH, uncontrolled recursion DoS), CVE-2026-52132 (CVSS 7.5 HIGH, integer overflow DoS via negative parameter), CVE-2026-52131 (CVSS 5.5 MEDIUM, reachable assertion when loading a malicious model file)"
+
+      - label: "Bug Bounty FVEs (4) — FindTheGap"
+        details: "Reported access control and missing authentication defects in production web/API services: 1 account takeover (CVSS 9.8 Critical) and 3 personal data exposures (CVSS 7.5 High) — root cause identified at source-code level and reproduced 100% across distinct accounts"
 
     projects:
       - name: "ELECCON — KEPCO Cyber Warfare Exercise"

--- a/scripts/cv/Hong_Seungpyo_CV_tuv_kor.yaml
+++ b/scripts/cv/Hong_Seungpyo_CV_tuv_kor.yaml
@@ -16,7 +16,7 @@ cv:
 
   sections:
     요약:
-      - "산업제어시스템(OT/ICS)·임베디드 보안 6년 경력. LS ELECTRIC 자동화기기를 IEC 62443-4-2 위협분석 및 위험평가(TARA)부터 Achilles Level 2 인증까지 지원했으며, CVE 21건(Linux Kernel 16 + IoT 5) 보유. 모의해킹·익스플로잇 개발과 결함을 인증 심사를 통과하는 감사 증적으로 옮기는 데 강점 — RED(EN 18031)·Cyber Resilience Act·NIS2 컴플라이언스 평가로 직접 전이 가능한 기반. NATO CCDCOE Locked Shields 2025 DFIR CTF 1위."
+      - "산업제어시스템(OT/ICS)·임베디드 보안 6년 경력. LS ELECTRIC 자동화기기를 IEC 62443-4-2 위협분석 및 위험평가(TARA)부터 Achilles Level 2 인증까지 지원했으며, CVE 24건(Linux Kernel 16 + IoT 5 + LLM 3) 보유. 모의해킹·익스플로잇 개발과 결함을 인증 심사를 통과하는 감사 증적으로 옮기는 데 강점 — RED(EN 18031)·Cyber Resilience Act·NIS2 컴플라이언스 평가로 직접 전이 가능한 기반. NATO CCDCOE Locked Shields 2025 DFIR CTF 1위."
 
     경력:
       - company: 코어시큐리티 (CoreSecurity)
@@ -71,8 +71,11 @@ cv:
       - label: "IoT CVE 5건 — 개인 연구"
         details: "임베디드/IoT 장비 취약점 분석 (UART 펌웨어 접근, binwalk 플래시 추출). CVE-2024-33788 (CVSS 8.0 HIGH), CVE-2024-33789 (CVSS 9.8 CRITICAL), CVE-2024-33791 (CVSS 4.6 MEDIUM), CVE-2024-33792 (CVSS 9.8 CRITICAL), CVE-2024-33793 (CVSS 5.3 MEDIUM)"
 
-      - label: "버그바운티 3건 — 접근통제 결함"
-        details: "프로덕션 웹 서비스 취약점 신고. 인증 없이 전 회원 비밀번호 변경 가능 (CVSS 9.8 Critical, Broken Access Control) 포함 3건 — 소스코드 수준 근본 원인 규명 및 서로 다른 계정으로 100% 재현"
+      - label: "LLM CVE 3건 — 개인 연구"
+        details: "제품에 편입되는 AI 추론 컴포넌트(llama.cpp)의 공급망·견고성 결함을 표준 관점에서 검증. CVE-2026-52130 (CVSS 7.5 HIGH, 무제어 재귀 DoS), CVE-2026-52132 (CVSS 7.5 HIGH, 음수 파라미터 정수 오버플로 DoS), CVE-2026-52131 (CVSS 5.5 MEDIUM, 악성 모델 파일 로드 시 도달 가능한 어서션)"
+
+      - label: "버그바운티 FVE 4건 — FindTheGap"
+        details: "프로덕션 웹/API 접근통제·인증 미적용 결함 신고. 계정 탈취 1건 (CVSS 9.8 Critical), 개인정보 노출 3건 (CVSS 7.5 High) — 소스코드 수준 근본 원인 규명 및 서로 다른 계정으로 100% 재현"
 
     프로젝트:
       - name: "ELECCON — 한국전력 사이버 공방 훈련"

--- a/scripts/cv/Hong_Seungpyo_CV_xbow.yaml
+++ b/scripts/cv/Hong_Seungpyo_CV_xbow.yaml
@@ -13,7 +13,7 @@ cv:
 
   sections:
     summary:
-      - "Offensive Security Researcher with 6 years of hands-on penetration testing and vulnerability research. Derived **21 CVEs** (OS Kernel 16 + IoT 5) through independent fuzzing and reverse engineering. Built an AI Orchestration Framework that autonomously identifies vulnerabilities on live targets — using IDA Pro, Burp Suite, Frida, and CodeQL orchestrated via MCP + A2A. NATO CCDCOE Locked Shields 2025 DFIR CTF #1."
+      - "Offensive Security Researcher with 6 years of hands-on penetration testing and vulnerability research. Derived **24 CVEs** (OS Kernel 16 + IoT 5 + LLM 3) through independent fuzzing and reverse engineering. Built an AI Orchestration Framework that autonomously identifies vulnerabilities on live targets — using IDA Pro, Burp Suite, Frida, and CodeQL orchestrated via MCP + A2A. NATO CCDCOE Locked Shields 2025 DFIR CTF #1."
 
     experience:
       - company: CoreSecurity
@@ -55,6 +55,12 @@ cv:
 
       - label: "IoT CVEs (5) — Independent Research, 2024"
         details: "Reverse-engineered embedded firmware; identified and reproduced vulnerabilities with full PoC chains. CVE-2024-33789 & CVE-2024-33792 (CVSS **9.8 CRITICAL**), CVE-2024-33788 (CVSS 8.0 HIGH), CVE-2024-33791 (CVSS 4.6), CVE-2024-33793 (CVSS 5.3)"
+
+      - label: "LLM Inference Engine CVEs (3) — Independent Research, 2026"
+        details: "Audited llama.cpp's HTTP server and model loader by fuzzing structured inputs (JSON schemas, GGUF files, REST parameters), then hand-tracing each crash to root cause. CVE-2026-52130 (CVSS **7.5 HIGH**, CWE-674): unbounded recursion in json-schema-to-grammar — reproduced 8 MB stack exhaustion at recursion depth 7000+, and separated the vulnerable path (`/completions`) from the non-vulnerable one (`/v1/chat/completions`, which routes through jinja) to scope impact precisely. CVE-2026-52132 (CVSS **7.5 HIGH**, CWE-190): integer overflow from a negative `top_n` on `/rerank`, driving an oversized allocation and remote DoS. CVE-2026-52131 (CVSS 5.5, CWE-617): reachable assertion in `gguf_reader::read` — a crafted GGUF model aborts the process on load. Each finding shipped with a minimal PoC and an upstream patch-level root cause writeup."
+
+      - label: "Bug Bounty — 4 FVEs (FindTheGap)"
+        details: "Black-box web/API testing on live production targets. Four access control and authentication findings: missing authentication permitting account takeover across an entire user base, an unauthorized identity-verification endpoint leaking real names and phone numbers, and unauthenticated APIs enumerable for personal data (CVSS up to **9.8 CRITICAL**; CWE-284, CWE-306, CWE-200). All validated with reproducible request chains and reported through coordinated disclosure. Vendor and technical details withheld under program policy."
 
     projects:
       - name: AI Offensive Security Orchestration Framework

--- a/scripts/cv/career-statement-coupang.yaml
+++ b/scripts/cv/career-statement-coupang.yaml
@@ -16,12 +16,12 @@ cv:
 
   sections:
     요약:
-      - "Web/App·Mobile·API 침투 테스트와 레드팀 훈련을 중심으로 24건 이상의 공격 보안 프로젝트를 수행한 Offensive Security Researcher. 금융·공공 12개 사이트 모의해킹과 의료영상 플랫폼 Web/Mobile 진단을 수행했고, 국내 대형 유통사 프로덕션에서 CVSS 9.8 계정 탈취를 포함한 이커머스 버그바운티를 제보했습니다. NATO Locked Shields·한국전력 ELECCON에서 MITRE ATT&CK 기반 공격 시나리오를 설계했으며, Linux Kernel CVE 16건 + IoT CVE 5건, Locked Shields 2025 DFIR CTF 1위 보유."
+      - "Web/App·Mobile·API 침투 테스트와 레드팀 훈련을 중심으로 24건 이상의 공격 보안 프로젝트를 수행한 Offensive Security Researcher. 금융·공공 12개 사이트 모의해킹과 의료영상 플랫폼 Web/Mobile 진단을 수행했고, 국내 대형 유통사 프로덕션에서 CVSS 9.8 계정 탈취를 포함한 이커머스 버그바운티를 제보했습니다. NATO Locked Shields·한국전력 ELECCON에서 MITRE ATT&CK 기반 공격 시나리오를 설계했으며, Linux Kernel CVE 16건 + IoT CVE 5건 + LLM 추론 엔진 CVE 3건, Locked Shields 2025 DFIR CTF 1위 보유."
 
     핵심_역량:
       - bullet: "Web/App·Mobile·API 모의해킹 — 금융·공공 전자금융기반시설 12개 사이트, 의료영상 플랫폼(Web·Android/iOS), 이커머스 프로덕션 버그바운티(CVSS 9.8 계정 탈취)"
       - bullet: "레드팀 · 위협 시뮬레이션 — MITRE ATT&CK 기반 공격 시나리오 설계, NATO Locked Shields DFIR CTF 1위, 한국전력 ELECCON 4년 운영, APEX CTF 문제 개발"
-      - bullet: "취약점 연구 · 익스플로잇 — Linux Kernel File System Fuzzer로 CVE 16건 도출(CodeBlue·HITB 발표), IoT CVE 5건, 펌웨어(UART·binwalk) 분석"
+      - bullet: "취약점 연구 · 익스플로잇 — Linux Kernel File System Fuzzer로 CVE 16건 도출(CodeBlue·HITB 발표), IoT CVE 5건, LLM 추론 엔진(llama.cpp) HTTP API CVE 3건, 펌웨어(UART·binwalk) 분석"
       - bullet: "침투 테스트 자동화 · 도구 개발 — Python 기반 점검 자동화, LLM 취약점 분석 파이프라인(MCP), IoT/CCTV 침해사고 조사 도구"
       - bullet: "OT/ICS · 임베디드 · 인증 — IEC 62443-4-2 위협 모델링·인증(Achilles Level 2), 의료기기 FDA/eSTAR, 스마트선박 CBS 점검 (도메인 폭)"
 
@@ -220,8 +220,10 @@ cv:
         details: "커스텀 File System Fuzzer 설계·구현으로 Linux Kernel CVE 16건(0-day 포함) 도출. CodeBlue 2019(도쿄)·Hack In The Box 2019(암스테르담) 발표."
       - label: "IoT CVE 5건 — 개인 연구"
         details: "임베디드/IoT 장비 취약점 분석. CVE-2024-33788/33789/33791/33792/33793 (CVSS 최대 9.8 CRITICAL)."
-      - label: "이커머스 버그바운티 3건 — 프로덕션 웹/API 접근통제 결함"
-        details: "국내 대형 유통사 프로덕션 서비스 대상 웹/API 취약점 3건 신고. 인증 없이 임의 계정 탈취(CVSS 9.8, Broken Access Control), 개인정보 노출 2건(CVSS 7.5). 소스코드 수준 근본 원인 규명 및 100% 재현. (회사명·상세 비공개)"
+      - label: "LLM CVE 3건 — 개인 연구"
+        details: "llama.cpp 추론 서버 HTTP 엔드포인트 취약점 분석. CVE-2026-52130(/completions 무제어 재귀 DoS, CVSS 7.5)·CVE-2026-52132(/rerank 음수 top_n 정수 오버플로 DoS, CVSS 7.5) 등 원격 비인증 DoS 2건 포함."
+      - label: "프로덕션 웹/API 버그바운티 4건 — 인증·접근통제 결함"
+        details: "국내 대형 유통사 프로덕션 서비스 3건 — 인증 없이 임의 계정 탈취(CVSS 9.8, Broken Access Control), 개인정보 노출 2건(CVSS 7.5). 별개 데이터 플랫폼 1건 — API 무인증 IDOR로 실명 명부·연락처 열람(CVSS 7.5). 소스코드 수준 근본 원인 규명 및 100% 재현. (회사명·상세 비공개)"
 
     자격증 · 교육:
       - bullet: "리눅스 마스터 2급 (KAIT, 2021.07)"

--- a/scripts/cv/career-statement-hanwha.yaml
+++ b/scripts/cv/career-statement-hanwha.yaml
@@ -16,7 +16,7 @@ cv:
 
   sections:
     요약:
-      - "산업 제어(OT/ICS)·의료기기·선박 등 제조 제품의 사이버보안 인증과 규제 대응을 수행한 보안 엔지니어. LS ELECTRIC 자동화기기를 위협 모델링부터 IEC 62443-4-2 컴포넌트 인증(Achilles Level 2)까지 지원해 취득에 기여했고, 신약개발 연합학습 플랫폼(K-MELLODDY)에서 NIST SSDF 기반 보안 개발 생명주기(SDL) 정의와 공급망 보안 체계(SBOM/VEX/EoS)를 수립하며 EU CRA·IEC 62443·FDA를 검토했습니다. 금융/공공 Web/App 모의해킹 12개 사이트, Linux Kernel CVE 16건, IoT CVE 5건, NATO Locked Shields 2025 DFIR CTF 1위 보유."
+      - "산업 제어(OT/ICS)·의료기기·선박 등 제조 제품의 사이버보안 인증과 규제 대응을 수행한 보안 엔지니어. LS ELECTRIC 자동화기기를 위협 모델링부터 IEC 62443-4-2 컴포넌트 인증(Achilles Level 2)까지 지원해 취득에 기여했고, 신약개발 연합학습 플랫폼(K-MELLODDY)에서 NIST SSDF 기반 보안 개발 생명주기(SDL) 정의와 공급망 보안 체계(SBOM/VEX/EoS)를 수립하며 EU CRA·IEC 62443·FDA를 검토했습니다. 금융/공공 Web/App 모의해킹 12개 사이트, Linux Kernel CVE 16건, IoT CVE 5건, LLM 추론 엔진 CVE 3건, NATO Locked Shields 2025 DFIR CTF 1위 보유."
 
     핵심_역량:
       - bullet: "OT/ICS 제품 인증 — IEC 62443-4-2 위협 모델링·컴포넌트 요구사항(CR) 점검·모의해킹, LS ELECTRIC Achilles Level 2 통신 견고성 인증 취득 및 자동 점검 도구 개발"
@@ -220,8 +220,10 @@ cv:
         details: "커스텀 File System Fuzzer 설계·구현으로 Linux Kernel CVE 16건(0-day 포함) 도출. CodeBlue 2019(도쿄)·Hack In The Box 2019(암스테르담) 발표."
       - label: "IoT CVE 5건 — 개인 연구"
         details: "임베디드/IoT 장비 취약점 분석. CVE-2024-33788/33789/33791/33792/33793 (CVSS 최대 9.8 CRITICAL)."
-      - label: "FVE 3건 — Findthegap 버그바운티"
-        details: "버그바운티 플랫폼 대상 웹 취약점 보고 3건 (상세 비공개)."
+      - label: "LLM CVE 3건 — 개인 연구"
+        details: "llama.cpp 추론 엔진 취약점 분석. CVE-2026-52130/52131/52132 (원격 비인증 DoS 2건 CVSS 7.5 포함)."
+      - label: "FVE 4건 — Findthegap 버그바운티"
+        details: "버그바운티 플랫폼 대상 웹 취약점 보고 4건 (상세 비공개)."
 
     자격증 · 교육:
       - bullet: "리눅스 마스터 2급 (KAIT, 2021.07)"

--- a/scripts/cv/career-statement-ko.yaml
+++ b/scripts/cv/career-statement-ko.yaml
@@ -15,7 +15,7 @@ cv:
 
   sections:
     요약:
-      - "금융권 Web/App 모의해킹부터 OT/ICS(IEC 62443)·IoT·의료기기(FDA) 보안, 사이버 공방 훈련 개발까지 24건 이상의 프로젝트를 수행한 Offensive Security Researcher. LS ELECTRIC 자동화기기 Achilles Communication Certificate Level 2 인증 취득, NATO CCDCOE Locked Shields 2025 DFIR CTF 1위, Linux Kernel CVE 16건 + IoT CVE 5건 + FVE 3건 보유."
+      - "금융권 Web/App 모의해킹부터 OT/ICS(IEC 62443)·IoT·의료기기(FDA) 보안, 사이버 공방 훈련 개발까지 24건 이상의 프로젝트를 수행한 Offensive Security Researcher. LS ELECTRIC 자동화기기 Achilles Communication Certificate Level 2 인증 취득, NATO CCDCOE Locked Shields 2025 DFIR CTF 1위, Linux Kernel CVE 16건 + IoT CVE 5건 + LLM 추론 엔진 CVE 3건 + FVE 4건 보유."
 
     핵심_역량:
       - bullet: "금융·공공 전자금융기반시설 Web/App 모의해킹 — 저축은행·캐피탈·증권·보험·제조 등 12개 사이트 수행 (A3 Security)"
@@ -219,8 +219,10 @@ cv:
         details: "커스텀 File System Fuzzer 설계·구현으로 Linux Kernel CVE 16건(0-day 포함) 도출. CodeBlue 2019(도쿄)·Hack In The Box 2019(암스테르담) 발표."
       - label: "IoT CVE 5건 — 개인 연구"
         details: "임베디드/IoT 장비 취약점 분석. CVE-2024-33788/33789/33791/33792/33793 (CVSS 최대 9.8 CRITICAL)."
-      - label: "FVE 3건 — Findthegap 버그바운티"
-        details: "버그바운티 플랫폼 대상 웹 취약점 보고 3건 (상세 비공개)."
+      - label: "LLM CVE 3건 — 개인 연구"
+        details: "llama.cpp 추론 엔진 취약점 분석. CVE-2026-52130/52131/52132 (원격 비인증 DoS 2건 CVSS 7.5, 악성 GGUF 모델 로드 시 abort 1건)."
+      - label: "FVE 4건 — Findthegap 버그바운티"
+        details: "버그바운티 플랫폼 대상 웹 취약점 보고 4건 (상세 비공개)."
 
     자격증 · 교육:
       - bullet: "리눅스 마스터 2급 (KAIT, 2021.07)"


### PR DESCRIPTION
## 배경

PR #9에서 웹사이트(`/about`, `/portfolio`)에 신규 CVE/FVE를 반영했으나, `scripts/cv/`의 RenderCV 이력서 7종 + 경력기술서 3종은 그대로였다.

기존 총계가 `CVE 21건(Kernel 16 + IoT 5)`으로, 웹사이트(28)와도 실제(24)와도 달랐다. LLM 3건을 더해 **24건**으로 정정.

## 변경

| 항목 | 기존 | 수정 |
|---|---|---|
| CVE 총계 | `21건 (Kernel 16 + IoT 5)` | `24건 (Kernel 16 + IoT 5 + LLM 3)` |
| FVE | `3건` | `4건` |
| LLM CVE 항목 | 없음 | 10종 전부 신설 |

- **LLM 항목 위치** — 기존 연대순(Kernel 2019 → IoT 2024 → 버그바운티 2026)에 맞춰 IoT 뒤 / 버그바운티 앞.
- **FVE 항목** — `Hong_Seungpyo_CV.yaml`·`_tuv.yaml`·`_xbow.yaml` 3종에는 항목 자체가 없어 신설. 나머지는 기존 항목을 4건으로 확장(중복 신설 회피).

## 마스킹·톤 유지

- **신규 FVE는 기존 GS리테일 3건과 별개 대상**(데이터 플랫폼)이다. `_kor.yaml` 라벨이 `FVE 3건 — FindTheGap (GS리테일)`이라 단순히 4로 바꾸면 소속이 틀어져, 벤더명을 빼고 `별도 데이터 플랫폼 1건`으로 분리 서술했다.
- **coupang 계열** — 유통 경쟁사 맥락상 벤더명 익명화 관례 유지. `GS리테일`·`FindTheGap` 표기 **0건** 확인.
- 파일별 기존 톤 유지 — xbow는 발굴 파이프라인 서술, tuv는 인증·규제 근거, hanwha는 간결 서술.

## 건드리지 않은 것

- `File System Fuzzer` 프로젝트의 `CVE 16건` — 2019년 프로젝트 국소 실적이라 총계와 무관.
- career-statement의 `24건 이상의 프로젝트` — **프로젝트 건수**이며 CVE 총계 24와 숫자만 우연히 겹친다.

## 검증

- 10종 `yaml.safe_load` 통과
- 원본 대비 **키 구조 동일**(신규 키 없음) — 기존 `label`/`details` 형식만 사용
- 구값 잔존(`21건`/`FVE 3건`) 0건, 항목 중복 0건

⚠️ **PDF 렌더 미검증** — `rendercv` 설치가 `pydantic 2.8.2`와 충돌해 `rendercv --version`조차 실패한다. 수정 전 원본도 동일하게 실패하므로 이 변경과 무관한 기존 환경 문제다. 별도 조치 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)