### PR TITLE
feat(seo): 콘텐츠 페이지 SEO/AEO 메타데이터 근본 구현

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -10,6 +10,11 @@ import {
   hasLocaleOverride,
 } from "@/lib/content";
 import { routing, toBcp47 } from "@/i18n/routing";
+import {
+  buildContentMetadata,
+  buildContentJsonLd,
+  type SeoFrontmatter,
+} from "@/lib/seo";
 import { formatDate } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { PostSidebar } from "@/components/blog/post-sidebar";
@@ -52,8 +57,12 @@ async function importPost(locale: string, slug: string) {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale, slug } = await params;
   const mod = await importPost(locale, slug);
-  const title = (mod.frontmatter?.title as string) ?? slug;
-  return { title };
+  return buildContentMetadata({
+    section: "blog",
+    slug,
+    locale,
+    fm: (mod.frontmatter ?? {}) as SeoFrontmatter,
+  });
 }
 
 function serialize(item: NonNullable<ReturnType<typeof getContent>>): SerializedPost {
@@ -111,6 +120,17 @@ export default async function BlogPostPage({ params }: Props) {
 
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: buildContentJsonLd({
+            section: "blog",
+            slug,
+            locale,
+            fm: fm as SeoFrontmatter,
+          }),
+        }}
+      />
       <ReadingProgress />
 
       <div className="mx-auto w-[90vw] max-w-[1200px] px-4 py-8">

--- a/src/app/[locale]/cves/[slug]/page.tsx
+++ b/src/app/[locale]/cves/[slug]/page.tsx
@@ -11,6 +11,11 @@ import { ProseImageLightbox } from "@/components/blog/prose-image-lightbox";
 import { ReadingProgress } from "@/components/blog/reading-progress";
 import { ScrollToTop } from "@/components/blog/scroll-to-top";
 import { routing, toBcp47 } from "@/i18n/routing";
+import {
+  buildContentMetadata,
+  buildContentJsonLd,
+  type SeoFrontmatter,
+} from "@/lib/seo";
 import { formatDate } from "@/lib/utils";
 import {
   getAllSlugs,
@@ -57,9 +62,12 @@ async function importCve(locale: string, slug: string) {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale, slug } = await params;
   const mod = await importCve(locale, slug);
-  const title = (mod.frontmatter?.title as string) ?? slug;
-  const description = (mod.frontmatter?.summary as string) ?? undefined;
-  return { title, description };
+  return buildContentMetadata({
+    section: "cves",
+    slug,
+    locale,
+    fm: (mod.frontmatter ?? {}) as SeoFrontmatter,
+  });
 }
 
 export default async function CvePage({ params }: Props) {
@@ -139,6 +147,17 @@ export default async function CvePage({ params }: Props) {
 
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: buildContentJsonLd({
+            section: "cves",
+            slug,
+            locale,
+            fm: fm as SeoFrontmatter,
+          }),
+        }}
+      />
       <ReadingProgress />
 
       <div className="mx-auto w-[90vw] max-w-[1200px] px-4 py-8">

--- a/src/app/[locale]/writeups/[slug]/page.tsx
+++ b/src/app/[locale]/writeups/[slug]/page.tsx
@@ -5,6 +5,11 @@ import fs from "fs";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { getAllSlugs, hasLocaleOverride } from "@/lib/content";
 import { routing, toBcp47 } from "@/i18n/routing";
+import {
+  buildContentMetadata,
+  buildContentJsonLd,
+  type SeoFrontmatter,
+} from "@/lib/seo";
 import { formatDate } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -46,8 +51,12 @@ async function importWriteup(locale: string, slug: string) {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale, slug } = await params;
   const mod = await importWriteup(locale, slug);
-  const title = (mod.frontmatter?.title as string) ?? slug;
-  return { title };
+  return buildContentMetadata({
+    section: "writeups",
+    slug,
+    locale,
+    fm: (mod.frontmatter ?? {}) as SeoFrontmatter,
+  });
 }
 
 export default async function WriteupPage({ params }: Props) {
@@ -73,6 +82,17 @@ export default async function WriteupPage({ params }: Props) {
 
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: buildContentJsonLd({
+            section: "writeups",
+            slug,
+            locale,
+            fm: fm as SeoFrontmatter,
+          }),
+        }}
+      />
       <ReadingProgress />
 
       <div className="mx-auto w-[90vw] max-w-[1200px] px-4 py-8">

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,35 @@
+import type { MetadataRoute } from "next";
+
+// Required for `output: export` — emit robots.txt as a static file at build.
+export const dynamic = "force-static";
+
+const BASE = "https://phantomn.github.io";
+
+/**
+ * robots.txt — explicitly allow AI answer-engine crawlers so the site is
+ * eligible for citation in ChatGPT / Claude / Perplexity / Copilot answers
+ * (AEO). Search crawlers get the same open access; nothing here is private.
+ */
+export default function robots(): MetadataRoute.Robots {
+  const aiCrawlers = [
+    "GPTBot", // OpenAI / ChatGPT
+    "OAI-SearchBot", // ChatGPT search
+    "ChatGPT-User", // ChatGPT browsing
+    "ClaudeBot", // Anthropic Claude
+    "Claude-Web",
+    "PerplexityBot", // Perplexity
+    "Perplexity-User",
+    "Google-Extended", // Gemini training/grounding
+    "Applebot-Extended",
+    "CCBot", // Common Crawl (feeds many models)
+  ];
+
+  return {
+    rules: [
+      { userAgent: "*", allow: "/" },
+      ...aiCrawlers.map((userAgent) => ({ userAgent, allow: "/" })),
+    ],
+    sitemap: `${BASE}/sitemap.xml`,
+    host: BASE,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,52 @@
+import type { MetadataRoute } from "next";
+import { routing, toBcp47 } from "@/i18n/routing";
+import { getAllSlugs } from "@/lib/content";
+
+// Required for `output: export` — emit sitemap.xml as a static file at build.
+export const dynamic = "force-static";
+
+const BASE = "https://phantomn.github.io";
+
+const STATIC_PAGES = ["", "about", "portfolio", "toolbox", "blog", "writeups", "cves"];
+const CONTENT_SECTIONS = ["blog", "writeups", "cves"];
+
+/** Full URL for a locale + path, trailing slash (site uses trailingSlash: true). */
+function url(locale: string, subpath: string): string {
+  const suffix = subpath ? `${subpath}/` : "";
+  return `${BASE}/${locale}/${suffix}`;
+}
+
+/** hreflang alternates: same set of locales for every entry + x-default. */
+function languagesFor(subpath: string): Record<string, string> {
+  const languages: Record<string, string> = {};
+  for (const loc of routing.locales) {
+    languages[toBcp47(loc)] = url(loc, subpath);
+  }
+  languages["x-default"] = url(routing.defaultLocale, subpath);
+  return languages;
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const entries: MetadataRoute.Sitemap = [];
+
+  // Static + list pages, one canonical entry per path (default locale).
+  for (const page of STATIC_PAGES) {
+    entries.push({
+      url: url(routing.defaultLocale, page),
+      alternates: { languages: languagesFor(page) },
+    });
+  }
+
+  // Content detail pages.
+  for (const section of CONTENT_SECTIONS) {
+    for (const slug of getAllSlugs(section)) {
+      const subpath = `${section}/${slug}`;
+      entries.push({
+        url: url(routing.defaultLocale, subpath),
+        alternates: { languages: languagesFor(subpath) },
+      });
+    }
+  }
+
+  return entries;
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,158 @@
+import type { Metadata } from "next";
+import { routing, toBcp47 } from "@/i18n/routing";
+
+/**
+ * Single source of truth for per-content-page metadata (SEO + AEO).
+ *
+ * Every content detail page (blog / writeups / cves) builds its `<head>` from
+ * this one function instead of hand-rolling a `{ title }` object each. That
+ * keeps canonical URLs, hreflang alternates, Open Graph, and Twitter cards
+ * consistent — and means a new content type gets full metadata for free.
+ *
+ * Domain resolution relies on `metadataBase` (set once in the root layout), so
+ * the relative paths returned here are expanded to absolute URLs by Next.js.
+ */
+
+const SITE_NAME = "Ph4nt0m";
+
+/** Frontmatter fields this builder reads. All optional except title. */
+export interface SeoFrontmatter {
+  title?: string;
+  /** Long-form posts use `description`; CVEs use `summary`. */
+  description?: string;
+  summary?: string;
+  date?: string;
+  modified?: string;
+  tags?: string[];
+  authors?: Array<{ name: string; link?: string; image?: string }>;
+  image?: string;
+}
+
+export interface BuildMetaInput {
+  /** URL section segment, e.g. "blog" | "writeups" | "cves". */
+  section: string;
+  slug: string;
+  locale: string;
+  fm: SeoFrontmatter;
+}
+
+/** Path for a given locale, with trailing slash (site uses trailingSlash: true). */
+function pagePath(locale: string, section: string, slug: string): string {
+  return `/${locale}/${section}/${slug}/`;
+}
+
+/**
+ * Build hreflang alternates: every locale lists the same full set + x-default.
+ * Google requires each localized page to reference all its siblings.
+ */
+function buildLanguages(
+  section: string,
+  slug: string,
+): Record<string, string> {
+  const languages: Record<string, string> = {};
+  for (const loc of routing.locales) {
+    languages[toBcp47(loc)] = pagePath(loc, section, slug);
+  }
+  languages["x-default"] = pagePath(routing.defaultLocale, section, slug);
+  return languages;
+}
+
+export function buildContentMetadata({
+  section,
+  slug,
+  locale,
+  fm,
+}: BuildMetaInput): Metadata {
+  const title = fm.title ?? slug;
+  const description = fm.description ?? fm.summary ?? undefined;
+  const canonical = pagePath(locale, section, slug);
+  const authorNames = (fm.authors ?? []).map((a) => a.name);
+  const images = fm.image ? [{ url: fm.image, alt: title }] : undefined;
+
+  return {
+    title,
+    description,
+    authors: (fm.authors ?? []).map((a) => ({ name: a.name, url: a.link })),
+    keywords: fm.tags,
+    alternates: {
+      canonical,
+      languages: buildLanguages(section, slug),
+    },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      siteName: SITE_NAME,
+      type: "article",
+      locale: toBcp47(locale).replace("-", "_"),
+      publishedTime: fm.date,
+      modifiedTime: fm.modified ?? fm.date,
+      authors: authorNames.length ? authorNames : undefined,
+      tags: fm.tags,
+      images,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: fm.image ? [fm.image] : undefined,
+    },
+    robots: { index: true, follow: true },
+  };
+}
+
+/**
+ * JSON-LD structured data (AEO). Rendered by the page as a <script> element —
+ * the Next.js metadata API only emits <meta>/<link>, never <script>, so schema
+ * cannot live in generateMetadata. Returns Article + BreadcrumbList graph.
+ */
+export function buildContentJsonLd({
+  section,
+  slug,
+  locale,
+  fm,
+}: BuildMetaInput): string {
+  const base = "https://phantomn.github.io";
+  const url = base + pagePath(locale, section, slug);
+  const title = fm.title ?? slug;
+  const description = fm.description ?? fm.summary ?? undefined;
+
+  const article: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    headline: title,
+    description,
+    inLanguage: toBcp47(locale),
+    url,
+    mainEntityOfPage: { "@type": "WebPage", "@id": url },
+    datePublished: fm.date,
+    dateModified: fm.modified ?? fm.date,
+    keywords: (fm.tags ?? []).join(", ") || undefined,
+    image: fm.image ? base + fm.image : undefined,
+    author: (fm.authors ?? []).map((a) => ({
+      "@type": "Person",
+      name: a.name,
+      url: a.link,
+    })),
+    publisher: { "@type": "Organization", name: SITE_NAME, url: base },
+  };
+
+  const breadcrumb = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: section,
+        item: `${base}/${locale}/${section}/`,
+      },
+      { "@type": "ListItem", position: 2, name: title, item: url },
+    ],
+  };
+
+  // Strip undefined so the emitted JSON stays clean.
+  return JSON.stringify([article, breadcrumb], (_k, v) =>
+    v === undefined ? undefined : v,
+  );
+}


### PR DESCRIPTION
## 근본 원인

`generateMetadata`가 전 콘텐츠 타입(blog·writeups·cves)에서 `{ title }` 수준에 멈춰 있었다 — description·canonical·hreflang·OpenGraph·JSON-LD 전무. 각 페이지가 독립 구현이라 **재발 구조**(새 타입마다 누락).

## 정공법 (증상 fix 아님)

**메타 생성을 SSOT로 통합** — 증상(blog에만 OG 추가)이 아니라 패턴 자체를 끊었다.

- **`lib/seo.ts` 신설**: `buildContentMetadata`(canonical·hreflang 4로케일+`x-default`·OG article·twitter) + `buildContentJsonLd`(TechArticle+BreadcrumbList). 중복 3벌 → 한 곳.
- **3개 상세 페이지가 공용 빌더 소비**: 새 콘텐츠 타입도 전체 메타 무료 획득.
- **`sitemap.ts`**: 121 URL, 전 로케일 hreflang alternates.
- **`robots.ts`**: AI 크롤러(GPTBot·ClaudeBot·PerplexityBot·Google-Extended 등) 명시 허용 = **AEO 인용 자격**. `output:export` 대응 `force-static`.

## 조사 근거 (exa 전수조사)

Next.js 15 공식 + AEO 2026 가이드(HubSpot·Similarweb·AirOps·RocketLauncher) 수렴:
- JSON-LD는 `generateMetadata` 아닌 페이지 `<script>`로 (메타 API엔 jsonLd 없음)
- AI 크롤러 명시 허용이 AEO 진입 자격
- 리치 스키마 = 인용 확률 2.8배(AirOps), 정량 통계+출처 = 최대 41%↑(Princeton GEO-Bench)
- 정적 HTML 필수 → 이 사이트 `output:export`라 이미 충족

## 검증 (렌더 HTML 실측)

- blog/writeups/cves 전부: description(글별)·canonical·hreflang 5개·og:type=article·twitter·JSON-LD
- sitemap.xml 121 URL · robots.txt AI 크롤러 허용 · 빌드 490 페이지 통과

## 참고

`layout.tsx`의 `metadataBase`는 조사 중 도메인 불일치를 의심했으나, 실측 결과 `phantomn.github.io`가 실제 서빙 도메인이라 원복(net 변경 0). CNAME의 `Ph4nt0m.tech`는 미보유 도메인으로 별개 이슈.

🤖 Generated with [Claude Code](https://claude.com/claude-code)