### PR TITLE
fix(seo): robots.txt AI 검색 크롤러 실측 기준 갱신

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -11,17 +11,26 @@ const BASE = "https://phantomn.github.io";
  * (AEO). Search crawlers get the same open access; nothing here is private.
  */
 export default function robots(): MetadataRoute.Robots {
+  // Three crawler roles per AI vendor: training / search-index / live-agent.
+  // Search-index bots are the ones that decide citation eligibility.
   const aiCrawlers = [
-    "GPTBot", // OpenAI / ChatGPT
-    "OAI-SearchBot", // ChatGPT search
-    "ChatGPT-User", // ChatGPT browsing
-    "ClaudeBot", // Anthropic Claude
-    "Claude-Web",
-    "PerplexityBot", // Perplexity
-    "Perplexity-User",
-    "Google-Extended", // Gemini training/grounding
+    // OpenAI
+    "GPTBot", // training
+    "OAI-SearchBot", // ChatGPT search index → citation eligibility
+    "ChatGPT-User", // live user-triggered fetch
+    // Anthropic
+    "ClaudeBot", // training
+    "Claude-SearchBot", // Claude search index → citation eligibility
+    "Claude-User", // live user-triggered fetch
+    // Perplexity
+    "PerplexityBot", // search index
+    "Perplexity-User", // live fetch
+    // Google (Gemini) — robots token, no distinct HTTP UA; Googlebot does the crawl
+    "Google-Extended",
+    // Apple Intelligence
     "Applebot-Extended",
-    "CCBot", // Common Crawl (feeds many models)
+    // Common Crawl (feeds many models)
+    "CCBot",
   ];
 
   return {


### PR DESCRIPTION
exa 전수조사로 현행 AI 크롤러명 확정 후 robots.txt 보강.

## 변경
- **Claude 검색 크롤러 갱신**: `Claude-SearchBot`·`Claude-User` 추가 (기존 `Claude-Web`은 구식) → Claude 답변 인용 자격 확보
- 크롤러 3분류(training / search-index / live-agent) 주석 명확화
- Google-Extended가 HTTP UA 아닌 robots 토큰임을 명시

## 조사 근거 (llms.txt 안 만드는 이유)

여러 독립 실측이 llms.txt 무효를 확인:
- Ahrefs 137K 도메인: **97%가 fetch 0회**
- Limy 5억 봇 이벤트: 검색 크롤러 fetch **408건(0.00008%)**
- SE Ranking 30만 / Trakkr 3.8만 도메인: **인용률 상관 0** (p=0.85)
- Google 공식: "검색용 아님, 코딩 도구용 임시방편"

→ 검색 크롤러(GPTBot·ClaudeBot·PerplexityBot)는 llms.txt 건너뛰고 **정적 HTML 직접 파싱**. 이 사이트는 `output:export`라 이미 충족(정적 HTML 파싱 성공률 94% vs JS 23%).

빌드 490 페이지 통과, robots.txt에 Claude-SearchBot·Claude-User 렌더 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)