### PR TITLE
feat(domain): 커스텀 도메인 blog.ph4nt0m.xyz 이전 + 도메인 SSOT화

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-Ph4nt0m.tech

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,13 @@
+/**
+ * Single source of truth for site-wide identity constants.
+ *
+ * The production origin is hardcoded in exactly one place here. Everything that
+ * needs an absolute URL (metadataBase, canonical, sitemap, robots, JSON-LD)
+ * imports SITE_URL from this module — so a domain move is a one-line change,
+ * not a grep-and-hope across four files.
+ *
+ * Must stay in sync with `public/CNAME` (the file GitHub Pages reads to bind the
+ * custom domain). The two together define where the site lives.
+ */
+export const SITE_URL = "https://blog.ph4nt0m.xyz";
+export const SITE_NAME = "Ph4nt0m";


### PR DESCRIPTION
## 근본 문제
- 프로덕션 도메인이 4개 파일에 하드코딩(SSOT 위반) — 이전마다 재발 소지
- **CNAME 파일 2개 모순**: 루트=`Ph4nt0m.tech`(유령 도메인·死파일), `public/CNAME`=`phantomn.github.io`(실제 적용분). GitHub Pages는 빌드 산출물 CNAME을 쓰므로 루트 CNAME은 무의미했다.

## 정공법
- **`src/lib/site.ts` 신설 = 도메인 SSOT**. `SITE_URL` 1곳.
- layout(metadataBase)·seo(JSON-LD)·robots·sitemap 4곳이 `SITE_URL` 소비. 다음 이전은 1줄.
- `public/CNAME` → `blog.ph4nt0m.xyz`. 死 루트 CNAME 삭제.

## 검증
- 빌드 490 페이지 통과, 타입 에러 0
- canonical·og:url·JSON-LD·sitemap·out/CNAME 전부 `blog.ph4nt0m.xyz`, 구 도메인 잔여 0
- DNS 전파·custom domain 연결 확인 완료(HTTP 200, GitHub Pages "DNS check successful")

🤖 Generated with [Claude Code](https://claude.com/claude-code)