### PR TITLE
fix(domain): SSOT 소비 누락분 완결 — 4파일 SITE_URL + public/CNAME

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,1 @@
-phantomn.github.io
+blog.ph4nt0m.xyz

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,15 +1,16 @@
 import type { Metadata } from "next";
 import { ThemeProvider } from "@/components/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { SITE_URL, SITE_NAME } from "@/lib/site";
 import "@/styles/globals.css";
 
 export const metadata: Metadata = {
   title: {
-    default: "Ph4nt0m",
-    template: "%s — Ph4nt0m",
+    default: SITE_NAME,
+    template: `%s — ${SITE_NAME}`,
   },
   description: "Hacking and general cybersecurity.",
-  metadataBase: new URL("https://phantomn.github.io"),
+  metadataBase: new URL(SITE_URL),
 };
 
 export default function RootLayout({

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,9 +1,10 @@
 import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/site";
 
 // Required for `output: export` — emit robots.txt as a static file at build.
 export const dynamic = "force-static";
 
-const BASE = "https://phantomn.github.io";
+const BASE = SITE_URL;
 
 /**
  * robots.txt — explicitly allow AI answer-engine crawlers so the site is

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,11 +1,12 @@
 import type { MetadataRoute } from "next";
 import { routing, toBcp47 } from "@/i18n/routing";
 import { getAllSlugs } from "@/lib/content";
+import { SITE_URL } from "@/lib/site";
 
 // Required for `output: export` — emit sitemap.xml as a static file at build.
 export const dynamic = "force-static";
 
-const BASE = "https://phantomn.github.io";
+const BASE = SITE_URL;
 
 const STATIC_PAGES = ["", "about", "portfolio", "toolbox", "blog", "writeups", "cves"];
 const CONTENT_SECTIONS = ["blog", "writeups", "cves"];

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { routing, toBcp47 } from "@/i18n/routing";
+import { SITE_URL, SITE_NAME } from "@/lib/site";
 
 /**
  * Single source of truth for per-content-page metadata (SEO + AEO).
@@ -12,8 +13,6 @@ import { routing, toBcp47 } from "@/i18n/routing";
  * Domain resolution relies on `metadataBase` (set once in the root layout), so
  * the relative paths returned here are expanded to absolute URLs by Next.js.
  */
-
-const SITE_NAME = "Ph4nt0m";
 
 /** Frontmatter fields this builder reads. All optional except title. */
 export interface SeoFrontmatter {
@@ -112,7 +111,7 @@ export function buildContentJsonLd({
   locale,
   fm,
 }: BuildMetaInput): string {
-  const base = "https://phantomn.github.io";
+  const base = SITE_URL;
   const url = base + pagePath(locale, section, slug);
   const title = fm.title ?? slug;
   const description = fm.description ?? fm.summary ?? undefined;


### PR DESCRIPTION
## 문제

직전 PR #20이 `site.ts` SSOT는 만들었으나, 이를 소비하는 **4파일(layout·seo·robots·sitemap) + public/CNAME 변경이 커밋에 누락**됐다(git add 누락, "2 files changed"만 반영). 결과:
- main의 이 파일들이 여전히 `phantomn.github.io` 하드코딩
- 배포 CNAME(`phantomn.github.io`)과 GitHub Pages custom domain 설정(`blog.ph4nt0m.xyz`)이 어긋남

## 수정

- layout(metadataBase/title)·seo(base/publisher)·robots(BASE)·sitemap(BASE) 4파일이 `SITE_URL`·`SITE_NAME` 소비
- seo.ts의 `SITE_NAME` 자체정의 제거 → site.ts import
- `public/CNAME` → `blog.ph4nt0m.xyz`

## 검증
- 빌드 490 페이지 통과, 타입 에러 0
- canonical·sitemap·robots·out/CNAME 전부 `blog.ph4nt0m.xyz`
- src/·public/ 도메인 잔여 스캔 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)