### PR TITLE
feat(seo): Bing Webmaster HTML 메타태그 검증 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,9 @@ export const metadata: Metadata = {
   },
   description: "Hacking and general cybersecurity.",
   metadataBase: new URL(SITE_URL),
+  verification: {
+    other: { "msvalidate.01": "E505121A3A724E9FA08F34071E4F8D0C" },
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## 배경
DNS(CNAME) 검증이 Bing 검증기 내부 캐시 문제로 반복 실패. DNS 자체는 4개 공용 리졸버(8.8.8.8, 1.1.1.1, 208.67.222.222, Cloudflare authoritative) 전부 정상 확인됨에도 Bing 검증기만 감지 못함.

## 변경
DNS 방식 대신 **HTML 메타태그** 검증으로 전환. Next.js metadata API의 `verification.other` 로 `msvalidate.01` 을 전 페이지 `<head>` 에 렌더.

정적 사이트라 배포 즉시 반영 — DNS 전파 대기 불필요.

## 검증
빌드 후 `out/index.html`, `out/ko/index.html` 양쪽에 메타태그 렌더 확인:
```html
<meta name="msvalidate.01" content="..."/>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)