### PR TITLE
feat(seo): Google Search Console HTML 태그 검증 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
   description: "Hacking and general cybersecurity.",
   metadataBase: new URL(SITE_URL),
   verification: {
+    google: "gVTemYAsJEhb36XfmaxV2RgOBXyj4vqQ8dTfzSdmYko",
     other: { "msvalidate.01": "E505121A3A724E9FA08F34071E4F8D0C" },
   },
 };


### PR DESCRIPTION
## 변경
`blog.ph4nt0m.xyz` URL 접두어 속성 검증용 `google-site-verification` 메타태그를 Next.js metadata API의 `verification.google` 로 추가. Bing `msvalidate.01` 태그와 나란히 전 페이지 `<head>` 렌더.

## 검증
빌드 후 `out/index.html` 에 양 태그 확인:
```html
<meta name="google-site-verification" content="..."/>
<meta name="msvalidate.01" content="..."/>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)