### PR TITLE
feat(analytics): GA4 연동 (@next/third-parties GoogleAnalytics)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "@mdx-js/loader": "^3.1.1",
         "@mdx-js/react": "^3.1.1",
         "@next/mdx": "^16.1.6",
+        "@next/third-parties": "^16.3.0",
+        "@types/mdast": "^4.0.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2",
         "cmdk": "^1.1.1",
@@ -44,6 +46,7 @@
         "shiki": "^4.0.2",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3",
+        "unist-util-visit": "^5.1.0",
         "vaul": "^1.1.2"
       },
       "devDependencies": {
@@ -1022,6 +1025,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.3.0.tgz",
+      "integrity": "sha512-cAA96hSI9NC7083b6sEsKjgyvM/YJ2eqXs4HWv8a/z5LE12CL1sUJS+cmcTwNMY4yAFpLyyuZHrMBEfh/4Xupw==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -5269,7 +5285,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7230,17 +7245,6 @@
         }
       }
     },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -8340,6 +8344,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
     "@next/mdx": "^16.1.6",
+    "@next/third-parties": "^16.3.0",
     "@types/mdast": "^4.0.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { GoogleAnalytics } from "@next/third-parties/google";
 import { ThemeProvider } from "@/components/theme-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { SITE_URL, SITE_NAME } from "@/lib/site";
@@ -41,6 +42,7 @@ export default function RootLayout({
           <TooltipProvider>{children}</TooltipProvider>
         </ThemeProvider>
       </body>
+      <GoogleAnalytics gaId="G-KV41V41G5J" />
     </html>
   );
 }


### PR DESCRIPTION
## 변경
측정 ID `G-KV41V41G5J` 를 `@next/third-parties/google` 의 `GoogleAnalytics` 컴포넌트로 root layout 에 추가.

- 손코딩 gtag 스니펫 대신 Next.js 공식 컴포넌트 사용 — `next/script` 최적화(hydration 후 로드) 내장
- gtag.js 는 클라이언트 스크립트라 `output: export` 정적 사이트와 호환 (빌드 시점 아닌 브라우저 실행)

## 목적
AI 어시스턴트(ChatGPT/Perplexity 등) referral 유입을 GA4 채널로 분리 측정하기 위한 기반. 채널 그룹 설정은 GA4 콘솔에서 별도 진행.

## 검증
빌드 후 `out/index.html` 에 GA 스크립트 + 측정 ID 확인:
```
G-KV41V41G5J
googletagmanager.com/gtag
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)