### PR TITLE
fix(ci): npm10 기준 package-lock 재생성해 배포 실패 근본 해결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5285,6 +5285,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7243,6 +7244,17 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next-themes": {


### PR DESCRIPTION
## 증상
PR #24(GA4) 배포가 `npm ci` 단계에서 11초 만에 실패:
```
npm error code EUSAGE
npm error Missing: @swc/helpers@0.5.23 from lock file
```
결과: 라이브 전 페이지에서 GA 태그 누락(이전 #23 배포 상태로 고정).

## 근본 원인
lock 이 **로컬 npm12** 로 생성됨.
- `@next/third-parties` 의 peer dependency: `@swc/helpers >=0.5.17`
- npm12: peer 를 관대하게 해석 → 기존 `0.5.15` 로 충족 처리, lock 에 `0.5.23` 항목 안 남김
- CI(node22 / **npm10**): 엄격 → 별도 `0.5.23` 트리 항목을 요구 → `EUSAGE` 거부

→ **npm12 lock 은 npm12 에서만 `npm ci` 통과.** 로컬 통과·CI 실패의 원인.

## 재현
node22/npm10(nvm)에서 `npm ci --dry-run` → 정확히 동일한 `Missing: @swc/helpers@0.5.23` 에러 재현 확인.

## 해결
`rerun` 은 같은 lock 이라 재실패하는 임시 처방. **lock 자체**를 고침:
- CI 와 동일한 node22/npm10 환경에서 `npm install` → lock 에 `@swc/helpers@0.5.23` 별도 트리 항목 추가(2곳)
- 동일 환경에서 `npm ci`(EXIT 0) + `npm run build` 통과 확인
- GA 태그(`G-KV41V41G5J`) 빌드 출력 검증

## diff
`package-lock.json` 12줄 추가 (0.5.23 트리 항목).

🤖 Generated with [Claude Code](https://claude.com/claude-code)